### PR TITLE
Modifying job from Python shell to Spark for bigger local storage

### DIFF
--- a/batch/stacks/glue_restore_job.py
+++ b/batch/stacks/glue_restore_job.py
@@ -61,16 +61,18 @@ class GlueRestoreOnDemandStack(Stack):
             config_filename = 'glue_config.conf'         
         aws_glue.CfnJob(self, "LFRestoreOnDemandGlueJob",role=glue_role.role_arn,
                 command=aws_glue.CfnJob.JobCommandProperty(
-                    name="pythonshell",
-                    python_version="3.9",
-                    
+                    name="glueetl",
+                    python_version="3",
                     script_location="s3://"+script_bucket.bucket_name+"/app.py"
                 ),
                 default_arguments={
                     '--CONFIG_BUCKET':config_bucket,
-                    '--CONFIG_FILE_KEY': config_filename
+                    '--CONFIG_FILE_KEY': config_filename,
+                    '--additional-python-modules': 'awswrangler == 3.4.0'
                 },
-                max_capacity=1
+                glue_version= "4.0",
+                worker_type="G.1X",
+                number_of_workers = 2
             )
         
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


The changes are made in the Glue Job type from Glue Python shell to Glue Spark and this will allow storage of bigger files, particularly suitable to work with Glue catalog which has large number of databases and tables and partitions. 