### PR TITLE
Fix Iceberg .avro metadata rewrite to update S3 bucket references in …

### DIFF
--- a/batch/infra/stacks/glue_restore_job.py
+++ b/batch/infra/stacks/glue_restore_job.py
@@ -136,7 +136,7 @@ class GlueRestoreOnDemandStack(Stack):
             default_arguments={
                 "--CONFIG_BUCKET": config_bucket,
                 "--CONFIG_FILE_KEY": config_filename,
-                "--additional-python-modules": "awswrangler==3.9.1",
+                "--additional-python-modules": "awswrangler==3.9.1,fastavro",
             },
             glue_version="5.0",
             worker_type="G.1X",

--- a/batch/script/app.py
+++ b/batch/script/app.py
@@ -8,6 +8,7 @@ to run as an AWS Glue ETL job.
 from __future__ import annotations
 
 import ast
+import io
 import json
 import logging
 import os
@@ -148,6 +149,115 @@ def update_table_location(table_data: dict, table_s3_mapping: dict[str, str]) ->
     return table_data
 
 
+def _remap_s3_string(value: str, table_s3_mapping: dict[str, str]) -> str:
+    """Replace source bucket references in a string with target buckets."""
+    for src_bkt, tgt_bkt in table_s3_mapping.items():
+        value = value.replace(f"s3://{src_bkt}/", f"s3://{tgt_bkt}/")
+        value = value.replace(f"s3a://{src_bkt}/", f"s3a://{tgt_bkt}/")
+    return value
+
+
+def _rewrite_avro_file(
+    s3_uri: str,
+    table_s3_mapping: dict[str, str],
+    s3_client,
+    target_bucket: str,
+    rewritten: set[str],
+) -> None:
+    """Download an Avro file from S3, rewrite all string fields that contain
+    S3 bucket references, and upload to the target bucket.
+
+    Iceberg uses Avro for manifest-list files (``snap-*.avro``) and manifest
+    files.  Both contain S3 paths as plain strings — in ``manifest_path``,
+    ``manifest-list``, and ``data_file.file_path`` among others.  Rather than
+    hard-coding field names we walk every record and rewrite any string that
+    matches a bucket in the mapping.
+
+    *rewritten* tracks already-processed URIs to avoid duplicate work when
+    multiple snapshots share the same manifest.
+    """
+    if s3_uri in rewritten:
+        return
+    rewritten.add(s3_uri)
+
+    parsed = urlparse(s3_uri)
+    source_bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+
+    if source_bucket not in table_s3_mapping:
+        return
+
+    try:
+        import fastavro
+    except ImportError:
+        logger.warning("fastavro not available — skipping Avro rewrite for %s", s3_uri)
+        return
+
+    try:
+        resp = s3_client.get_object(Bucket=source_bucket, Key=key)
+        raw_bytes = resp["Body"].read()
+
+        buf_in = io.BytesIO(raw_bytes)
+        reader = fastavro.reader(buf_in)
+        schema = reader.writer_schema
+
+        # Read all records, collecting source .avro URIs *before* rewriting
+        records = []
+        source_child_uris: list[str] = []
+        for record in reader:
+            _collect_avro_uris(record, table_s3_mapping, source_child_uris)
+            _rewrite_avro_record(record, table_s3_mapping)
+            records.append(record)
+
+        buf_out = io.BytesIO()
+        fastavro.writer(buf_out, schema, records)
+
+        s3_client.put_object(
+            Bucket=target_bucket,
+            Key=key,
+            Body=buf_out.getvalue(),
+            ContentType="application/avro",
+        )
+        logger.info("Rewrote Avro file: s3://%s/%s -> s3://%s/%s", source_bucket, key, target_bucket, key)
+
+        # Recursively rewrite any .avro files referenced within (manifests from manifest-lists)
+        for child_uri in source_child_uris:
+            _rewrite_avro_file(child_uri, table_s3_mapping, s3_client, target_bucket, rewritten)
+
+    except Exception as exc:
+        logger.error("Failed to rewrite Avro file %s: %s", s3_uri, exc)
+
+
+def _collect_avro_uris(obj: Any, table_s3_mapping: dict[str, str], uris: list[str]) -> None:
+    """Walk an Avro record and collect any .avro S3 URIs whose bucket is in the mapping.
+
+    These are the *source* URIs (before rewriting) so we know where to fetch them from.
+    """
+    if isinstance(obj, dict):
+        for v in obj.values():
+            _collect_avro_uris(v, table_s3_mapping, uris)
+    elif isinstance(obj, list):
+        for v in obj:
+            _collect_avro_uris(v, table_s3_mapping, uris)
+    elif isinstance(obj, str) and obj.endswith(".avro"):
+        parsed = urlparse(obj)
+        if parsed.netloc in table_s3_mapping:
+            uris.append(obj)
+
+
+def _rewrite_avro_record(obj: Any, table_s3_mapping: dict[str, str]) -> Any:
+    """Recursively walk an Avro record (dict/list/str) and rewrite S3 paths."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            obj[k] = _rewrite_avro_record(v, table_s3_mapping)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            obj[i] = _rewrite_avro_record(v, table_s3_mapping)
+    elif isinstance(obj, str):
+        return _remap_s3_string(obj, table_s3_mapping)
+    return obj
+
+
 def rewrite_iceberg_metadata(
     metadata_s3_uri: Optional[str],
     table_s3_mapping: dict[str, str],
@@ -155,6 +265,10 @@ def rewrite_iceberg_metadata(
 ) -> Optional[str]:
     """Download an Iceberg metadata JSON from S3, rewrite embedded bucket
     references, and upload to the target bucket.
+
+    Also rewrites any ``.avro`` manifest-list and manifest files referenced
+    in the metadata so that all S3 paths in the Iceberg metadata tree point
+    to the target bucket.
 
     Returns the new S3 URI (in the target bucket).
     """
@@ -173,17 +287,34 @@ def rewrite_iceberg_metadata(
     try:
         key = parsed.path.lstrip("/")
         resp = s3_client.get_object(Bucket=source_bucket, Key=key)
-        content = resp["Body"].read().decode("utf-8")
+        original_content = resp["Body"].read().decode("utf-8")
 
-        for src_bkt, tgt_bkt in table_s3_mapping.items():
-            content = content.replace(f"s3://{src_bkt}/", f"s3://{tgt_bkt}/")
-            content = content.replace(f"s3a://{src_bkt}/", f"s3a://{tgt_bkt}/")
+        # Collect .avro URIs from the *original* metadata (source bucket paths)
+        # before rewriting, so we know where to fetch them from.
+        avro_source_uris: list[str] = []
+        try:
+            original_metadata = json.loads(original_content)
+            for snapshot in original_metadata.get("snapshots", []):
+                uri = snapshot.get("manifest-list", "")
+                if uri and uri.endswith(".avro"):
+                    avro_source_uris.append(uri)
+        except json.JSONDecodeError:
+            pass
+
+        # Rewrite and upload the JSON metadata file
+        content = _remap_s3_string(original_content, table_s3_mapping)
 
         s3_client.put_object(
             Bucket=target_bucket, Key=key, Body=content.encode("utf-8"), ContentType="application/json"
         )
         new_uri = f"s3://{target_bucket}/{key}"
         logger.info("Rewrote Iceberg metadata: %s -> %s", metadata_s3_uri, new_uri)
+
+        # --- Rewrite .avro manifest-list and manifest files ---
+        rewritten: set[str] = set()
+        for avro_uri in avro_source_uris:
+            _rewrite_avro_file(avro_uri, table_s3_mapping, s3_client, target_bucket, rewritten)
+
         return new_uri
 
     except Exception as exc:

--- a/tests/test_batch_app.py
+++ b/tests/test_batch_app.py
@@ -4,10 +4,12 @@ Covers:
 - update_location (S3 URL remapping via urlparse)
 - update_table_location (Hive, Iceberg metadata_location, previous_metadata_location, AdditionalLocations)
 - update_database_location
-- rewrite_iceberg_metadata (S3 metadata file rewriting)
+- rewrite_iceberg_metadata (S3 metadata file rewriting + .avro manifest rewriting)
+- _rewrite_avro_file / _rewrite_avro_record (Avro binary rewriting)
 - _process_restore_line ordering (database, table, partition routing)
 """
 
+import io
 import json
 import os
 import sys
@@ -256,6 +258,171 @@ class TestRewriteIcebergMetadata(unittest.TestCase):
     def test_none_uri_passthrough(self):
         result = app.rewrite_iceberg_metadata(None, self.mapping, "us-east-1")
         self.assertIsNone(result)
+
+    @patch.object(app, "get_client")
+    def test_rewrites_avro_manifest_files(self, mock_get_client):
+        """Verify that .avro manifest-list files referenced in metadata JSON are rewritten."""
+        import fastavro
+
+        mock_s3 = MagicMock()
+        mock_get_client.return_value = mock_s3
+
+        # --- Build a fake Avro manifest-list file with source bucket paths ---
+        manifest_list_schema = {
+            "type": "record",
+            "name": "manifest_file",
+            "fields": [
+                {"name": "manifest_path", "type": "string"},
+                {"name": "manifest_length", "type": "long"},
+                {"name": "partition_spec_id", "type": "int"},
+            ],
+        }
+        manifest_list_records = [
+            {
+                "manifest_path": "s3://src-bucket-east/warehouse/db/tbl/metadata/m0.avro",
+                "manifest_length": 1234,
+                "partition_spec_id": 0,
+            },
+        ]
+        avro_buf = io.BytesIO()
+        fastavro.writer(avro_buf, manifest_list_schema, manifest_list_records)
+        avro_bytes = avro_buf.getvalue()
+
+        # --- Build a fake Avro manifest file (the child m0.avro) ---
+        manifest_schema = {
+            "type": "record",
+            "name": "manifest_entry",
+            "fields": [
+                {"name": "status", "type": "int"},
+                {
+                    "name": "data_file",
+                    "type": {
+                        "type": "record",
+                        "name": "data_file",
+                        "fields": [
+                            {"name": "file_path", "type": "string"},
+                            {"name": "file_size_in_bytes", "type": "long"},
+                        ],
+                    },
+                },
+            ],
+        }
+        manifest_records = [
+            {
+                "status": 1,
+                "data_file": {
+                    "file_path": "s3://src-bucket-east/warehouse/db/tbl/data/part-00000.parquet",
+                    "file_size_in_bytes": 5678,
+                },
+            },
+        ]
+        child_avro_buf = io.BytesIO()
+        fastavro.writer(child_avro_buf, manifest_schema, manifest_records)
+        child_avro_bytes = child_avro_buf.getvalue()
+
+        # --- JSON metadata referencing the manifest-list .avro ---
+        metadata_json = json.dumps(
+            {
+                "format-version": 2,
+                "location": "s3://src-bucket-east/warehouse/db/tbl",
+                "snapshots": [
+                    {
+                        "snapshot-id": 100,
+                        "manifest-list": "s3://src-bucket-east/warehouse/db/tbl/metadata/snap-100.avro",
+                    }
+                ],
+            }
+        )
+
+        # --- Mock S3 responses: metadata JSON, manifest-list .avro, manifest .avro ---
+        def mock_get_object(Bucket, Key):
+            if Key.endswith(".metadata.json"):
+                return {"Body": MagicMock(read=MagicMock(return_value=metadata_json.encode("utf-8")))}
+            elif "snap-100.avro" in Key:
+                return {"Body": MagicMock(read=MagicMock(return_value=avro_bytes))}
+            elif "m0.avro" in Key:
+                return {"Body": MagicMock(read=MagicMock(return_value=child_avro_bytes))}
+            raise ValueError(f"Unexpected key: {Key}")
+
+        mock_s3.get_object.side_effect = mock_get_object
+
+        # --- Invoke ---
+        result = app.rewrite_iceberg_metadata(
+            "s3://src-bucket-east/warehouse/db/tbl/metadata/v2.metadata.json",
+            self.mapping,
+            "us-east-1",
+        )
+
+        self.assertEqual(result, "s3://tgt-bucket-west/warehouse/db/tbl/metadata/v2.metadata.json")
+
+        # Verify put_object was called 3 times: JSON + manifest-list .avro + manifest .avro
+        self.assertEqual(mock_s3.put_object.call_count, 3)
+
+        # Check the manifest-list .avro was rewritten
+        avro_puts = [
+            c for c in mock_s3.put_object.call_args_list if c[1].get("ContentType") == "application/avro"
+        ]
+        self.assertEqual(len(avro_puts), 2)
+
+        # Parse the rewritten manifest-list to verify paths are remapped
+        snap_put = [c for c in avro_puts if "snap-100" in c[1]["Key"]][0]
+        rewritten_records = list(fastavro.reader(io.BytesIO(snap_put[1]["Body"])))
+        self.assertEqual(
+            rewritten_records[0]["manifest_path"],
+            "s3://tgt-bucket-west/warehouse/db/tbl/metadata/m0.avro",
+        )
+
+        # Parse the rewritten manifest to verify data file paths are remapped
+        m0_put = [c for c in avro_puts if "m0.avro" in c[1]["Key"]][0]
+        rewritten_manifest = list(fastavro.reader(io.BytesIO(m0_put[1]["Body"])))
+        self.assertEqual(
+            rewritten_manifest[0]["data_file"]["file_path"],
+            "s3://tgt-bucket-west/warehouse/db/tbl/data/part-00000.parquet",
+        )
+
+
+class TestRewriteAvroRecord(unittest.TestCase):
+    """Test the _rewrite_avro_record and _collect_avro_uris helpers."""
+
+    def test_rewrites_nested_strings(self):
+        mapping = {"src-bucket": "tgt-bucket"}
+        record = {
+            "manifest_path": "s3://src-bucket/meta/m0.avro",
+            "data_file": {
+                "file_path": "s3://src-bucket/data/part-0.parquet",
+                "size": 100,
+            },
+            "tags": ["s3://src-bucket/tags/a.txt", "other"],
+        }
+        app._rewrite_avro_record(record, mapping)
+        self.assertEqual(record["manifest_path"], "s3://tgt-bucket/meta/m0.avro")
+        self.assertEqual(record["data_file"]["file_path"], "s3://tgt-bucket/data/part-0.parquet")
+        self.assertEqual(record["tags"][0], "s3://tgt-bucket/tags/a.txt")
+        self.assertEqual(record["tags"][1], "other")
+
+    def test_leaves_non_matching_strings(self):
+        mapping = {"src-bucket": "tgt-bucket"}
+        record = {"path": "s3://other-bucket/data/file.parquet"}
+        app._rewrite_avro_record(record, mapping)
+        self.assertEqual(record["path"], "s3://other-bucket/data/file.parquet")
+
+    def test_collect_avro_uris_finds_source_uris(self):
+        mapping = {"src-bucket": "tgt-bucket"}
+        record = {
+            "manifest_path": "s3://src-bucket/meta/m0.avro",
+            "data_file": {"file_path": "s3://src-bucket/data/part-0.parquet"},
+        }
+        uris: list[str] = []
+        app._collect_avro_uris(record, mapping, uris)
+        # Only .avro files are collected, not .parquet
+        self.assertEqual(uris, ["s3://src-bucket/meta/m0.avro"])
+
+    def test_collect_avro_uris_ignores_unmapped_buckets(self):
+        mapping = {"src-bucket": "tgt-bucket"}
+        record = {"manifest_path": "s3://other-bucket/meta/m0.avro"}
+        uris: list[str] = []
+        app._collect_avro_uris(record, mapping, uris)
+        self.assertEqual(uris, [])
 
 
 class TestProcessRestoreLine(unittest.TestCase):


### PR DESCRIPTION
…manifest files

Previously only the JSON metadata files had S3 paths rewritten during cross-region replication. Avro manifest-list (snap-*.avro) and manifest (*.avro) files still referenced the source bucket, breaking Iceberg table reads in the target region.

Adds recursive Avro binary file rewriting using fastavro:
- _remap_s3_string: shared s3:// and s3a:// path replacement
- _rewrite_avro_file: download, rewrite, upload Avro files
- _collect_avro_uris: walk records to find child .avro references
- _rewrite_avro_record: recursively rewrite S3 paths in Avro records

Adds fastavro to Glue job --additional-python-modules. Includes unit and end-to-end tests for all new functions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
